### PR TITLE
gh-129015: Move link suppression around in a Note for exceptions.rst

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -335,9 +335,9 @@ The following exceptions are the exceptions that are usually raised.
 
    .. note::
 
-      ``NotImplementedError`` and :data:`NotImplemented` are not interchangeable,
+      ``NotImplementedError`` and :data:`!NotImplemented` are not interchangeable,
       even though they have similar names and purposes.  See
-      :data:`!NotImplemented` for details on when to use it.
+      :data:`NotImplemented` for details on when to use it.
 
 .. exception:: OSError([arg])
                OSError(errno, strerror[, filename[, winerror[, filename2]]])


### PR DESCRIPTION
This makes it similar to the same text in constants.rst.